### PR TITLE
skip list validation for etherscan "list" aka "fulllist"

### DIFF
--- a/src/lib/token_list_gen.ts
+++ b/src/lib/token_list_gen.ts
@@ -55,6 +55,7 @@ export const generateTokenList = async (
     includeUnbridgedL1Tokens?: boolean;
     getAllTokensInNetwork?: boolean;
     includeOldDataFields?: boolean;
+    skipValidation?: boolean;
   }
 ) => {
   if (options?.includeAllL1Tokens && options.includeUnbridgedL1Tokens) {
@@ -335,7 +336,9 @@ export const generateTokenList = async (
     ...arbTokenList,
     tokens: arbTokenList.tokens,
   };
-  validateTokenListWithErrorThrowing(validationTokenList);
+  if(!options?.skipValidation){
+    validateTokenListWithErrorThrowing(validationTokenList);
+  }
 
   console.log(`Generated list with total ${arbTokenList.tokens.length} tokens`);
   console.log('version:', version);
@@ -395,6 +398,7 @@ export const generateFullList = async () => {
   };
   const tokenData = await generateTokenList(mockList, undefined, {
     getAllTokensInNetwork: true,
+    skipValidation: true
   });
 
   const etherscanData = arbListtoEtherscanList(tokenData);


### PR DESCRIPTION
validation unnecessary; we're just generating the L1 to L2 tokens mapping