### PR TITLE
Update list task

### DIFF
--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -18,7 +18,7 @@ export const listNameToFileName = (name: string) => {
   return fileName;
 };
 
-const getPath = (l1ListName: string) => {
+export const getPath = (l1ListName: string) => {
   if (l1ListName === ETHERSCAN_LIST_NAME) {
     if (isArbOne) return ETHERSCAN_PATH;
     if (isGoerliRollup) return ALL_TOKENS_GOERLI_ROLLUP_PATH;
@@ -48,7 +48,10 @@ export const getPrevList = (l1ListName: string): ArbTokenList | undefined => {
   return undefined;
 };
 
-export const writeToFile = (list: ArbTokenList | EtherscanList) => {
+export const writeToFile = (
+  list: ArbTokenList | EtherscanList,
+  path: string
+) => {
   if (!existsSync(TOKENLIST_DIR_PATH)) {
     console.log(`Setting up token list dir at ${TOKENLIST_DIR_PATH}`);
     mkdirSync(TOKENLIST_DIR_PATH);
@@ -59,7 +62,6 @@ export const writeToFile = (list: ArbTokenList | EtherscanList) => {
     mkdirSync(FULLLIST_DIR_PATH);
   }
 
-  const path = getPath('name' in list ? list.name : ETHERSCAN_LIST_NAME);
   writeFileSync(path, JSON.stringify(list));
   console.log('Token list generated at', path);
 };

--- a/src/lib/token_list_gen.ts
+++ b/src/lib/token_list_gen.ts
@@ -369,7 +369,10 @@ export const generateTokenList = async (
 export const arbifyL1List = async (
   pathOrUrl: string,
   includeOldDataFields?: boolean
-): Promise<ArbTokenList> => {
+): Promise<{
+  newList: ArbTokenList;
+  l1ListName: string;
+}> => {
   const l1TokenList = await promiseErrorMultiplier(
     getTokenListObj(pathOrUrl),
     (error) => getTokenListObj(pathOrUrl)
@@ -384,7 +387,10 @@ export const arbifyL1List = async (
     sourceListURL: isValidHttpUrl(pathOrUrl) ? pathOrUrl : undefined,
   });
 
-  return newList;
+  return {
+    newList,
+    l1ListName: l1TokenList.name,
+  };
 };
 
 export const updateArbifiedList = async (pathOrUrl: string) => {
@@ -409,7 +415,10 @@ export const updateArbifiedList = async (pathOrUrl: string) => {
     sourceListURL: isValidHttpUrl(pathOrUrl) ? pathOrUrl : undefined,
   });
 
-  return newList;
+  return {
+    newList,
+    path,
+  };
 };
 
 export const generateFullList = async () => {
@@ -444,16 +453,15 @@ export const generateFullListFormatted = async () => {
     },
     tokens: [],
   };
-  const allTokenList =   await generateTokenList(mockList, undefined, {
+  const allTokenList = await generateTokenList(mockList, undefined, {
     getAllTokensInNetwork: true,
     skipValidation: true,
   });
   // log for human-readable check
-  allTokenList.tokens.forEach((token)=>{
+  allTokenList.tokens.forEach((token) => {
     console.log(token.name, token.symbol, token.address);
-    
-  })
-  return allTokenList
+  });
+  return allTokenList;
 };
 
 // export const updateLogoURIs = async (path: string)=> {

--- a/src/lib/token_list_gen.ts
+++ b/src/lib/token_list_gen.ts
@@ -57,6 +57,7 @@ export const generateTokenList = async (
     includeOldDataFields?: boolean;
     sourceListURL?: string;
     skipValidation?: boolean;
+    preserveListName?: boolean
   }
 ) => {
   if (options?.includeAllL1Tokens && options.includeUnbridgedL1Tokens) {
@@ -337,7 +338,7 @@ export const generateTokenList = async (
   })();
   const sourceListURL = getFormattedSourceURL(options?.sourceListURL);
   const arbTokenList: ArbTokenList = {
-    name: listNameToArbifiedListName(name),
+    name: (options && options.preserveListName) ? name :  listNameToArbifiedListName(name),
     timestamp: new Date().toISOString(),
     version,
     tokens: arbifiedTokenList,
@@ -368,7 +369,7 @@ export const generateTokenList = async (
 
 export const arbifyL1List = async (
   pathOrUrl: string,
-  includeOldDataFields?: boolean
+  includeOldDataFields: boolean
 ): Promise<{
   newList: ArbTokenList;
   l1ListName: string;
@@ -393,7 +394,7 @@ export const arbifyL1List = async (
   };
 };
 
-export const updateArbifiedList = async (pathOrUrl: string) => {
+export const updateArbifiedList = async (pathOrUrl: string, includeOldDataFields: boolean) => {
   const arbTokenList = await getTokenListObj(pathOrUrl);
   removeInvalidTokensFromList(arbTokenList);
   const path =
@@ -413,6 +414,8 @@ export const updateArbifiedList = async (pathOrUrl: string) => {
   const newList = await generateTokenList(arbTokenList, prevArbTokenList, {
     includeAllL1Tokens: true,
     sourceListURL: isValidHttpUrl(pathOrUrl) ? pathOrUrl : undefined,
+    includeOldDataFields,
+    preserveListName: true
   });
 
   return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,16 +22,17 @@ const main = async () => {
 
   let tokenList: ArbTokenList;
   let path: string;
+  const includeOldDataFields:boolean =  !!args.includeOldDataFields
 
   if (args.action === 'arbify') {
     const { newList, l1ListName } = await arbifyL1List(
       args.tokenList,
-      !!args.includeOldDataFields
+      includeOldDataFields
     );
     tokenList = newList;
     path = getPath(l1ListName);
   } else if (args.action === 'update') {
-    const { newList, path: _path } = await updateArbifiedList(args.tokenList);
+    const { newList, path: _path } = await updateArbifiedList(args.tokenList, includeOldDataFields);
     tokenList = newList;
     path = _path;
   } else if (args.action === 'alltokenslist') {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,12 +2,13 @@ import {
   arbifyL1List,
   updateArbifiedList,
   generateFullList,
-  generateFullListFormatted
+  generateFullListFormatted,
 } from './lib/token_list_gen';
 import { addPermitTags } from './PermitTokens/permitSignature';
 import args from './lib/getClargs';
 import { ArbTokenList, EtherscanList } from './lib/types';
-import { writeToFile } from './lib/store';
+import { writeToFile, getPath } from './lib/store';
+import { ETHERSCAN_LIST_NAME } from './lib/constants';
 
 const main = async () => {
   if (args.action === 'full') {
@@ -16,26 +17,32 @@ const main = async () => {
     if (args.includePermitTags)
       throw new Error('full list mode does not support permit tagging');
 
-    return writeToFile(await generateFullList());
+    return writeToFile(await generateFullList(), getPath(ETHERSCAN_LIST_NAME));
   }
 
   let tokenList: ArbTokenList;
+  let path: string;
 
   if (args.action === 'arbify') {
-    tokenList = await arbifyL1List(args.tokenList, !!args.includeOldDataFields);
+    const { newList, l1ListName } = await arbifyL1List(
+      args.tokenList,
+      !!args.includeOldDataFields
+    );
+    tokenList = newList;
+    path = getPath(l1ListName);
   } else if (args.action === 'update') {
-    tokenList = await updateArbifiedList(args.tokenList);
-  }  else  if(args.action === 'alltokenslist') {
-    tokenList = await generateFullListFormatted()
-  }
-  
-  else {
+    const { newList, path: _path } = await updateArbifiedList(args.tokenList);
+    tokenList = newList;
+    path = _path;
+  } else if (args.action === 'alltokenslist') {
+    tokenList = await generateFullListFormatted();
+    path = getPath('full');
+  } else {
     throw new Error(`action ${args.action} not recognised`);
   }
 
   if (args.includePermitTags) tokenList = await addPermitTags(tokenList);
-
-  writeToFile(tokenList);
+  writeToFile(tokenList, path);
 };
 
 main()

--- a/update_all
+++ b/update_all
@@ -5,6 +5,8 @@ yarn fullList --l2NetworkID 42161
 yarn arbify --l2NetworkID 42161 --tokenList https://gateway.ipfs.io/ipns/tokens.uniswap.org
 yarn arbify --l2NetworkID 42161 --tokenList https://www.gemini.com/uniswap/manifest.json
 yarn arbify --l2NetworkID 42161 --tokenList https://api.coinmarketcap.com/data-api/v3/uniswap/all.json
+# update whitelist era list (for e.g. changed gateways)
+yarn update --l2NetworkID 42161 --tokenList ./src/ArbTokenLists/arbed_arb_whitelist_era.json --includeOldDataFields true
 
 # nova
 # yarn fullList --l2NetworkID 42170


### PR DESCRIPTION
This updates the "update" task, which takes a pre-existing arbified list as its input and ensures its up to date (which amounts to checking that each tokens gateways haven't changed).

(Compare to the "arbify" task which takes an L1 token list as its input and outputs an arbified list).

This PR let's the "includeOldDataFields" param be passed in via the command line; this preserves any data field in the extensions not included in the uniswap standard, for e.g. backwards compatibility (there are 3 for our whitelist era list).

It also allows a new "preserveListName" option (i.e., use the same old list name for the new, outputted list) which is (obviously) what we want for the update task (vs. for arbify where we give the list a new name).

We add the update task to /ArbTokenLists/arbed_arb_whitelist_era.json which indeed is the whitelist era list, live on the sever. 

(The way list names / files name are handled can def be re-thought/simplified for the refactor)

fixes https://github.com/OffchainLabs/arb-token-lists/issues/51