### PR TITLE
fix: duplicated entry due to same address on L1 L2

### DIFF
--- a/src/lib/token_list_gen.ts
+++ b/src/lib/token_list_gen.ts
@@ -103,7 +103,7 @@ export const generateTokenList = async (
   const l1TokenAddresses =
     options && options.getAllTokensInNetwork && !isNova
       ? tokens.map(curr => curr.l1TokenAddr)
-      : l1TokenList.tokens.map(token => token.address);
+      : l1TokenList.tokens.filter(token => token.chainId === l1.provider.network.chainId).map(token => token.address);
 
   // const l1TokenAddresses = tokens.map(
   //   (token: GraphTokenResult) => token.l1TokenAddr


### PR DESCRIPTION
This fix an issue that when a list is updated it generate duplicate entries if the token have the same L1 and L2 address.