### PR TITLE
fix: Update online URL list for integration tests

### DIFF
--- a/__test__/integration/validateLists.test.ts
+++ b/__test__/integration/validateLists.test.ts
@@ -221,9 +221,9 @@ describe('Token Lists', () => {
           '--ignorePreviousList=true',
           '--newArbifiedList=./src/ArbTokenLists/all_tokens.json',
         ]),
-        fetch('https://tokenlist.arbitrum.io/FullList/all_tokens.json').then(
-          (response) => response.json(),
-        ),
+        fetch(
+          'https://tokenlist.arbitrum.io/ArbTokenLists/arbed_full.json',
+        ).then((response) => response.json()),
       ]);
 
       compareLists(localList, onlineList);


### PR DESCRIPTION
Update the online list URL in integration tests for `fullList` test